### PR TITLE
Make buildpack less chatty by default. Fix create script warnings with pack.

### DIFF
--- a/buildpacks/quarkus/bin/build
+++ b/buildpacks/quarkus/bin/build
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#TODO
-# - support build args via env var 
-
 set -eo pipefail
 
 echo "---> Quarkus Buildpack"
@@ -35,10 +32,19 @@ if [[ -f pom.xml ]]; then
 
     mvnCommand="mvn"
 
-    if [ $IS_NATIVE == 1 ]; then
-        buildCommand="$mvnCommand package -B -Dnative -DskipTests"
+    # Disable maven build progress unless requested.
+    if [ "$MAVEN_ENABLE_TRANSFER_PROGRESS" == "true" ]; then 
+      echo "Maven transfer progress enabled."
+      suppressDownloadDownloadingMaven=""
     else
-        buildCommand="$mvnCommand package -B -DskipTests"        
+      echo "Maven transfer progress disabled."
+      suppressDownloadDownloadingMaven="--no-transfer-progress"
+    fi
+
+    if [ $IS_NATIVE == 1 ]; then
+        buildCommand="$mvnCommand package -B $suppressDownloadDownloadingMaven -Dnative -DskipTests"
+    else
+        buildCommand="$mvnCommand package -B $suppressDownloadDownloadingMaven -DskipTests"        
     fi
 
     # Build the project using appropriate maven command
@@ -70,7 +76,7 @@ if [[ -f pom.xml ]]; then
         #TODO no need for lib layer if building uber-jar
         echo "Copying libs to libdeps layer"
         mkdir -p $LAYERS_DIR/1-libdeps/lib
-        cp -rv target/lib $LAYERS_DIR/1-libdeps/
+        cp -r target/lib $LAYERS_DIR/1-libdeps/
         echo -e 'launch = true' > $LAYERS_DIR/1-libdeps.toml
 
         #Move built app to a layer

--- a/create-buildpacks.sh
+++ b/create-buildpacks.sh
@@ -21,7 +21,7 @@ done
 for builder_dir in $(find ${BUILDERS_DIR} -maxdepth 1 -mindepth 1 -type d)
 do
   echo "---> Creating builder for builder $(basename ${builder_dir})"
-  pack create-builder redhat/buildpacks-builder-$(basename ${builder_dir}):latest --config ${builder_dir}/builder.toml
-  pack trust-builder redhat/buildpacks-builder-$(basename ${builder_dir}):latest
+  pack builder create redhat/buildpacks-builder-$(basename ${builder_dir}):latest --config ${builder_dir}/builder.toml
+  pack config trusted-builders add redhat/buildpacks-builder-$(basename ${builder_dir}):latest
 done
 


### PR DESCRIPTION
Suppress maven downloading/downloaded messages by default, remove verbose list of copied libs (used for debug). 

Add new buildpacks env var that can be used to re-enable the maven transfer messages if required.  'MAVEN_ENABLE_TRANSFER_PROGRESS' 

Fix warnings for deprecated usage of pack cli args by create script.