### PR TITLE
Install "which" RPM, used by mvnw and /usr/bin/mvn

### DIFF
--- a/stacks/jvm/base/Dockerfile
+++ b/stacks/jvm/base/Dockerfile
@@ -6,6 +6,10 @@ FROM registry.access.redhat.com/ubi8/openjdk-11
 ENV CNB_USER_ID=185
 ENV CNB_GROUP_ID=185
 
+USER 0
+RUN microdnf install -y which && microdnf clean all
+USER $CNB_USER_ID
+
 # Removing file containing unwanted default values
 RUN rm /opt/jboss/container/java/run/run-env.sh
 


### PR DESCRIPTION
This is one possible solution for #13: just make sure which is available, so that `mvnw` and `/usr/bin/mvn` just work if they try to call it.